### PR TITLE
Don't boot with debug log enabled

### DIFF
--- a/meta-k8s-setup/recipes-mukube/images/mukube-image.bb
+++ b/meta-k8s-setup/recipes-mukube/images/mukube-image.bb
@@ -24,7 +24,7 @@ podman \
 " 
 
 # systemd only writes to the last console: https://github.com/systemd/systemd/issues/9899
-APPEND += "random.trust_cpu=on hw_rng_model=virtio systemd.legacy_systemd_cgroup_controller=yes console=tty0 console=ttyS0,115200 debug"
+APPEND += "random.trust_cpu=on hw_rng_model=virtio systemd.legacy_systemd_cgroup_controller=yes console=tty0 console=ttyS0,115200"
 LABELS_LIVE := "boot"
 
 IMAGE_FEATURES = ""


### PR DESCRIPTION
It is too much information and isn't really useful, just annoying.