### PR TITLE
Mount the encrypted partition to /var/state instead of /var/volatile

### DIFF
--- a/kas-base.yaml
+++ b/kas-base.yaml
@@ -66,7 +66,7 @@ local_conf_header:
 
     HOSTTOOLS += "docker"
     # 1GiB
-    WIC_CREATE_EXTRA_ARGS = "--extra-space 4294967296"
+    WIC_CREATE_EXTRA_ARGS = "--extra-space 1073741824"
 
 bblayers_conf_header:
   meta-k8s-setup: |

--- a/meta-k8s-setup/recipes-core/base-files/base-files/50-volatile.conf
+++ b/meta-k8s-setup/recipes-core/base-files/base-files/50-volatile.conf
@@ -1,6 +1,6 @@
 [Partition]
 Type=linux-generic
-SizeMaxBytes=4G
+SizeMaxBytes=100M
 UUID=ce28e84c-ab6b-4852-9301-86083840b6f4
 Format=ext4
 Encrypt=key-file

--- a/meta-k8s-setup/recipes-core/base-files/base-files/crypttab
+++ b/meta-k8s-setup/recipes-core/base-files/base-files/crypttab
@@ -1,1 +1,1 @@
-volatile PARTUUID="ce28e84c-ab6b-4852-9301-86083840b6f4" /dev/null
+state PARTUUID="ce28e84c-ab6b-4852-9301-86083840b6f4" /dev/null

--- a/meta-k8s-setup/recipes-core/base-files/base-files/fstab
+++ b/meta-k8s-setup/recipes-core/base-files/base-files/fstab
@@ -4,6 +4,7 @@
 proc                 /proc                proc       defaults              0  0
 devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
 tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
-/dev/mapper/volatile /var/volatile ext4 defaults,x-systemd.requires=systemd-repart.service 0 1
+tmpfs                /var/volatile        tmpfs      defaults              0  0
+/dev/mapper/state    /var/state           ext4       defaults,x-systemd.requires=systemd-repart.service 0 1
 LABEL=config         /config              ext4       defaults              0  0
 

--- a/meta-k8s-setup/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-k8s-setup/recipes-core/base-files/base-files_%.bbappend
@@ -5,6 +5,7 @@ SRC_URI += "file://50-volatile.conf \
             file://crypttab"
 
 do_install:append() {
+	install -d ${D}${datadir}/state
 	install -d ${D}${libdir}/repart.d
 	install -m 0644 ${WORKDIR}/50-volatile.conf ${D}${libdir}/repart.d/
 	install -m 0644 ${WORKDIR}/40-config.conf ${D}${libdir}/repart.d/
@@ -12,5 +13,5 @@ do_install:append() {
 	install -d ${D}${sysconfdir}/
 	install -m 0644 ${WORKDIR}/crypttab ${D}${sysconfdir}/
 
-	ln -s /var/volatile/secureboot ${D}${datadir}/secureboot
+	ln -s /var/state/secureboot ${D}${datadir}/secureboot
 }


### PR DESCRIPTION
/var/volatile is not meant for persistent data and ex: logs shouldn't be
stored on the encrypted partition which is meant for important state.

---

Blocked by #14