### PR TITLE
Fix memory not getting freed when files are deleted from the ramrootfs

### DIFF
--- a/meta-k8s-setup/recipes-core/initrdscripts/initramfs-framework/ramrootfs
+++ b/meta-k8s-setup/recipes-core/initrdscripts/initramfs-framework/ramrootfs
@@ -12,7 +12,7 @@ ramrootfs_run() {
 		size="$((size/100*90))"
 		zram_dev="$(zramctl -f -s "${size}KiB")"
 		mkfs.ext4 -O ^has_journal "$zram_dev"
-		mount "$zram_dev" "$ROOTFS_DIR"
+		mount -o discard "$zram_dev" "$ROOTFS_DIR"
 		cp -a "$ROOTFS_DIR.org/." "$ROOTFS_DIR"
 
 		# Needed for https://www.freedesktop.org/software/systemd/man/systemd-gpt-auto-generator.html


### PR DESCRIPTION
From the kernel commit introducing the support in zram[1]:
"zram is ram based block device and can be used by backend of filesystem.
When filesystem deletes a file, it normally doesn't do anything on data
block of that file.  It just marks on metadata of that file.  This
behavior has no problem on disk based block device, but has problems on
ram based block device, since we can't free memory used for data block.
To overcome this disadvantage, there is REQ_DISCARD functionality.  If
block device support REQ_DISCARD and filesystem is mounted with discard
option, filesystem sends REQ_DISCARD to block device whenever some data
blocks are discarded.  All we have to do is to handle this request."

[1] https://github.com/torvalds/linux/commit/f4659d8e620d08bd1a84a8aec5d2f5294a242764