### PR TITLE
Support split DNS for giving the host access to the cluster's DNS

### DIFF
--- a/meta-k8s-setup/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-k8s-setup/recipes-core/systemd/systemd_%.bbappend
@@ -7,6 +7,9 @@ SRC_URI += "file://0001-gpt-auto-generator-Use-volatile-root-by-default-and-.pat
 PACKAGECONFIG = "efi openssl cryptsetup repart networkd resolved tpm2"
 do_install:append() {
 	install -d ${D}/efi
+
+	sed -i -e "s%^L! /etc/resolv.conf.*$%L! /etc/resolv.conf - - - - ../run/systemd/resolve/stub/resolv.conf%g" ${D}${exec_prefix}/lib/tmpfiles.d/etc.conf
+	ln -fs ../run/systemd/resolve/stub-resolv.conf ${D}${sysconfdir}/resolv-conf.systemd
 }
 FILES:${PN} += "/efi"
 RDEPENDS:${PN} += "packagegroup-base-vfat"


### PR DESCRIPTION
This is done by enabling systemd-resolved's stub resolver and adding a
resolved.conf.d overide for the cluster.local routing domain
(see mukube-configurator PR[2] for the latter).

This is needed so CRI-O can point to a http proxy running inside the
cluster.

[1] https://www.freedesktop.org/software/systemd/man/resolved.conf.html
[2] https://github.com/distributed-technologies/mukube-configurator/pull/34