### PR TITLE
Add sftp required by mukube-configurator

### DIFF
--- a/meta-k8s-setup/recipes-mukube/images/mukube-image.bb
+++ b/meta-k8s-setup/recipes-mukube/images/mukube-image.bb
@@ -26,6 +26,8 @@ amd-microcode \
 helm \
 gptfdisk \
 kernel-modules \
+openssh-ssh \
+openssh-sftp \
 " 
 
 # systemd only writes to the last console: https://github.com/systemd/systemd/issues/9899


### PR DESCRIPTION
This is requried by mukube-configurator for transfering the
kubeconfig[1]. sftp requires ssh.

[1] https://github.com/distributed-technologies/mukube-configurator/pull/41