### PR TITLE
Update broken Git URLs for meta-security/meta-selinux

### DIFF
--- a/kas-base.yaml
+++ b/kas-base.yaml
@@ -31,7 +31,7 @@ repos:
     url: https://git.yoctoproject.org/git/meta-virtualization
     refspec: honister
   meta-security: 
-    url: https://git.yoctoproject.org/cgit/cgit.cgi/meta-security/
+    url: https://git.yoctoproject.org/git/meta-security
     refspec: honister
     layers:
       .:
@@ -41,7 +41,7 @@ repos:
         repo: mukube
         path: patches/meta-security/misc/
   meta-selinux:
-    url: https://git.yoctoproject.org/cgit/cgit.cgi/meta-selinux/
+    url: https://git.yoctoproject.org/git/meta-selinux
     refspec: honister
   meta-intel:
     url: https://git.yoctoproject.org/git/meta-intel/


### PR DESCRIPTION
They old URLs don't work anymore.

- [ ] The new functionality was tested
- [ ] The tests were executed with `bitbake mukube-test-image -c testimage` and they all succeeded
- [ ] The new code was sufficiently documented
