### PR TITLE
Documentation: Added quick build elaboration reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ The aim of the project is to build a minimal Linux distribution capable of runni
 * Clone the repository into this folder, e.g. `~/yocto/mukube`
 * Install [`kas`](https://kas.readthedocs.io/en/latest/userguide.html#dependencies-installation) and create a `kas-local.yaml` file. A guide to configuring kas-local.yaml can be found in [local configurations for kas-local.yaml](#local-configurations-in-kas-localyaml).
 * Make sure you can run yocto by installing the [required packages](https://docs.yoctoproject.org/ref-manual/system-requirements.html#required-packages-for-the-build-host)
-* Build the project using kas by running `kas build --update mukube/kas-base.yaml`
+* Build the project using kas 
+  * Run `kas build --update mukube/kas-base.yaml` for the production image
+  * Run `kas build --update mukube/kas-dev.yaml` for the development image
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The aim of the project is to build a minimal Linux distribution capable of runni
 ### Quick build
 * Create a folder for the build, e.g. `~/yocto`
 * Clone the repository into this folder, e.g. `~/yocto/mukube`
-* Install [`kas`](https://kas.readthedocs.io/en/latest/userguide.html#dependencies-installation) and create a `kas-local.yaml` file
+* Install [`kas`](https://kas.readthedocs.io/en/latest/userguide.html#dependencies-installation) and create a `kas-local.yaml` file. A guide to configuring kas-local.yaml can be found in [local configurations for kas-local.yaml](#local-configurations-in-kas-localyaml).
 * Build the project using kas by running `kas build --update mukube/kas-base.yaml`
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The aim of the project is to build a minimal Linux distribution capable of runni
 * Create a folder for the build, e.g. `~/yocto`
 * Clone the repository into this folder, e.g. `~/yocto/mukube`
 * Install [`kas`](https://kas.readthedocs.io/en/latest/userguide.html#dependencies-installation) and create a `kas-local.yaml` file. A guide to configuring kas-local.yaml can be found in [local configurations for kas-local.yaml](#local-configurations-in-kas-localyaml).
+* Make sure you can run yocto by installing the [required packages](https://docs.yoctoproject.org/ref-manual/system-requirements.html#required-packages-for-the-build-host)
 * Build the project using kas by running `kas build --update mukube/kas-base.yaml`
 
 ## Documentation


### PR DESCRIPTION
I have added a line to the quick fix to make sure people are aware that documentation about the kas-local.yaml is further down the page.

- [ ] The new functionality was tested
- [ ] The tests were executed with `bitbake mukube-test-image -c testimage` and they all succeeded
- [ ] The new code was sufficiently documented
